### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
 jobs:
   init:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/stevius10/Proxmox-GitOps/security/code-scanning/2](https://github.com/stevius10/Proxmox-GitOps/security/code-scanning/2)

The best way to fix this problem is to add a `permissions:` key at the workflow root (top-level, before `jobs:`) in `.github/workflows/build.yml`, unless a job needs greater permissions. The minimal permission needed for checkout and read-only workflows is `contents: read`. If you later discover a job needs write to issues, pull requests, or other, you can add a more specific job-level override. 

Locate the top of the workflow, just after the `on:` block and before `jobs:`, and insert:

```yaml
permissions:
  contents: read
```

No import, definition, or other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
