### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   init:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/stevius10/Proxmox-GitOps/security/code-scanning/1](https://github.com/stevius10/Proxmox-GitOps/security/code-scanning/1)

To fix this issue, you should add a `permissions` block to the workflow. This block can be set either at the root level (applies to all jobs by default) or per job. Since the workflow only checks out the repository, builds containers, and does not appear to perform any operations requiring write access (such as creating tags, pushing code, opening/closing issues, or managing pull requests), you can safely set a minimal permission of `contents: read`. This restricts the GITHUB_TOKEN used in the workflow to only reading repository contents. To implement the fix, add the following block near the top of the file (after the `name` if present, or after the `on:` block if not):

```yaml
permissions:
  contents: read
```

No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
