### PR TITLE
refactor/mount-share-via-systemd

### DIFF
--- a/base/roles/mount/handlers/main.yml
+++ b/base/roles/mount/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Remount
+  ansible.builtin.command:
+    cmd: mount -a
+  changed_when: false
+  ignore_errors: true # avoid permission error for token auth.

--- a/base/roles/mount/tasks/main.yml
+++ b/base/roles/mount/tasks/main.yml
@@ -9,6 +9,16 @@
     mount_list: "{{ mount.split(',') | reject('equalto', '') | select('match', '^[A-Za-z0-9_]+$') | list }}"
   when: mount is defined
 
+- name: Create credentials file
+  ansible.builtin.copy:
+    dest: /root/.share
+    content: |
+      username={{ login }}
+      password={{ password }}
+    owner: root
+    group: root
+    mode: '0600'
+
 - name: Ensure mount directories exist
   ansible.builtin.file:
     path: "{{ '/share' if item == 'share' else '/share/' ~ item }}"
@@ -25,12 +35,17 @@
     src: "//{{ host }}/{{ item }}"
     path: "{{ '/share' if item == 'share' else '/share/' ~ item }}"
     fstype: cifs
-    opts: "username={{ login }},password={{ password }},uid=1000,gid=1000,vers=3.0"
+    opts: "credentials=/root/.share,uid=1000,gid=1000,vers=3.0,_netdev,x-systemd.requires=network-online.target,x-systemd.after=network-online.target,nofail"
     state: mounted
   loop: "{{ mount_list }}"
   loop_control:
     label: "{{ item }}"
+  notify:
+    - Reload systemd
 
-- name: Restart mount
-  ansible.builtin.command: mount -a
-  ignore_errors: yes # avoid permission error if token usage
+- name: Enable network waiting service
+  ansible.builtin.systemd:
+    name: systemd-networkd-wait-online.service
+    enabled: yes
+  notify:
+    - Remount

--- a/base/roles/mount/tasks/main.yml
+++ b/base/roles/mount/tasks/main.yml
@@ -30,22 +30,37 @@
   loop_control:
     label: "{{ item }}"
 
-- name: Enable mount
-  ansible.posix.mount:
-    src: "//{{ host }}/{{ item }}"
-    path: "{{ '/share' if item == 'share' else '/share/' ~ item }}"
-    fstype: cifs
-    opts: "credentials=/root/.share,uid=1000,gid=1000,vers=3.0,_netdev,x-systemd.requires=network-online.target,x-systemd.after=network-online.target,nofail"
-    state: mounted
+- name: Create mount service
+  ansible.builtin.template:
+    src: share.service.j2
+    dest: "/etc/systemd/system/{{ ('share' if item == 'share' else 'share-' ~ item) }}.service"
+    owner: root
+    group: root
+    mode: '0644'
   loop: "{{ mount_list }}"
   loop_control:
     label: "{{ item }}"
-  notify:
-    - Reload systemd
 
-- name: Enable network waiting service
+- name: Create mount timer
+  ansible.builtin.template:
+    src: share.timer.j2
+    dest: "/etc/systemd/system/{{ ('share' if item == 'share' else 'share-' ~ item) }}.timer"
+    owner: root
+    group: root
+    mode: '0644'
+  loop: "{{ mount_list }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Enable mount service
   ansible.builtin.systemd:
-    name: systemd-networkd-wait-online.service
+    name: "{{ ('share' if item == 'share' else 'share-' ~ item) }}.timer"
     enabled: yes
-  notify:
-    - Remount
+    state: started
+  loop: "{{ mount_list }}"
+  loop_control:
+    label: "{{ item }}"

--- a/base/roles/mount/templates/share.service.j2
+++ b/base/roles/mount/templates/share.service.j2
@@ -1,0 +1,13 @@
+{% set mount_path = '/share' if item == 'share' else '/share/' ~ item %}
+{% set unit_name = 'share' if item == 'share' else 'share-' ~ item %}
+[Unit]
+Description=mount {{ item }} to {{ mount_path }}
+After=network.target
+StartLimitIntervalSec=900
+StartLimitBurst=10
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mount -t cifs //192.168.178.254/{{ item }} {{ mount_path }} -o credentials=/root/.share,uid=1000,gid=1000,vers=3.0
+ExecStartPost=/usr/bin/bash -c 'mountpoint -q {{ mount_path }} && /usr/bin/systemctl stop --now {{ unit_name }}.timer || true'
+ExecStopPost=/usr/bin/bash -c '[ "$SERVICE_RESULT" = "start-limit-hit" ] && /usr/bin/systemctl stop --now {{ unit_name }}.timer || true'

--- a/base/roles/mount/templates/share.timer.j2
+++ b/base/roles/mount/templates/share.timer.j2
@@ -1,0 +1,11 @@
+{% set unit_name = 'share' if item == 'share' else 'share-' ~ item %}
+[Unit]
+Description=mount {{ item }} timer
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=3min
+Unit={{ unit_name }}.service
+
+[Install]
+WantedBy=timers.target

--- a/libs/share/templates/smb.conf.erb
+++ b/libs/share/templates/smb.conf.erb
@@ -18,8 +18,6 @@ fruit:resource = file
 fruit:model = MacSamba
 fruit:locking = none
 
-dirsort = yes
-
 fruit:posix_rename = yes
 fruit:veto_appledouble = no
 fruit:nfs_aces = no


### PR DESCRIPTION
**Mount independent of container boot order**: More resilient approach than current
- Refactored mounts from fstab to per-share services using timers